### PR TITLE
Allow sus low rated users to be reported

### DIFF
--- a/modules/evaluation/src/main/PlayerAggregateAssessment.scala
+++ b/modules/evaluation/src/main/PlayerAggregateAssessment.scala
@@ -44,8 +44,7 @@ case class PlayerAggregateAssessment(
       (cheatingSum >= 3 || cheatingSum + likelyCheatingSum >= 6) &&
       (percentCheatingGames(10) || percentLikelyCheatingGames(20))
 
-    val reportable: Boolean = isWorthLookingAt &&
-      (cheatingSum >= 2 || cheatingSum + likelyCheatingSum >= (isNewRatedUser.fold(2, 4))) &&
+    val reportable: Boolean = (cheatingSum >= 2 || cheatingSum + likelyCheatingSum >= (isNewRatedUser.fold(2, 4))) &&
       (percentCheatingGames(5) || percentLikelyCheatingGames(10))
 
     val bannable: Boolean = (relatedCheatersCount == relatedUsersCount) && relatedUsersCount >= 1


### PR DESCRIPTION
I've noticed that some very suspicious low rated players have gone completely un-noticed until user reported (and then marked by Irwin). It's probably a good idea to allow them to be auto-reported.